### PR TITLE
Default values, fix smallint & bigint, support mediumint

### DIFF
--- a/tabledump.tableplusplugin/library/helper.js
+++ b/tabledump.tableplusplugin/library/helper.js
@@ -59,33 +59,24 @@ function getColumnMigrate(columnName, dataType, isNullable) {
       break;
     case "int8":
     case "bigint":
-      if (dataType.includes("unsigned")) {
-        migration = "$table->unsignedBigInteger('" + columnName + "')";
-      } else {
-        migration = "$table->bigInteger('" + columnName + "')";
-      }
+      migration = "$table->bigInteger('" + columnName + "')";
       break;
     case "int":
     case "int4":
-      if (dataType.includes("unsigned")) {
-        migration = "$table->bigIncrements('" + columnName + "')";
-      } else {
-        migration = "$table->integer('" + columnName + "')";
-      }
+      migration = "$table->integer('" + columnName + "')";
       break;
     case "int2":
       migration = "$table->smallInteger('" + columnName + "')";
       break;
     case "tinyint":
-      if (dataType.includes("unsigned")) {
-        migration = "$table->unsignedTinyInteger('" + columnName + "')";
-      } else {
-        migration = "$table->tinyInteger('" + columnName + "')";
-      }
+      migration = "$table->tinyInteger('" + columnName + "')";
       break;
     default:
       migration = `$table->${typeOnly}('` + columnName + "')";
       break;
+  }
+  if (dataType.includes("unsigned")) {
+    migration += "->unsigned()";
   }
   if (isNullable.toLowerCase().startsWith("y")) {
     migration += "->nullable()";

--- a/tabledump.tableplusplugin/library/helper.js
+++ b/tabledump.tableplusplugin/library/helper.js
@@ -89,7 +89,7 @@ function getColumnMigrate(columnName, dataType, isNullable) {
   }
   if (defaultVal) {
   	// ensure non-ints are properly escaped
-  	if (['tinyint', 'int', 'int2', 'int4', 'int8', 'bigint'].indexOf(typeOnly) === -1) {
+  	if (!typeOnly.includes("int")) {
 	  defaultVal = JSON.stringify(defaultVal);
   	}
 	migration += "->default(" + defaultVal + ")";

--- a/tabledump.tableplusplugin/library/helper.js
+++ b/tabledump.tableplusplugin/library/helper.js
@@ -81,6 +81,13 @@ function getColumnMigrate(columnName, dataType, isNullable) {
   if (isNullable.toLowerCase().startsWith("y")) {
     migration += "->nullable()";
   }
+  if (defaultVal) {
+  	// ensure non-ints are properly escaped
+  	if (['tinyint', 'int', 'int2', 'int4', 'int8', 'bigint'].indexOf(typeOnly) === -1) {
+	  defaultVal = JSON.stringify(defaultVal);
+  	}
+	migration += "->default(" + defaultVal + ")";
+  }
   return migration + ";";
 }
 

--- a/tabledump.tableplusplugin/library/helper.js
+++ b/tabledump.tableplusplugin/library/helper.js
@@ -65,9 +65,15 @@ function getColumnMigrate(columnName, dataType, isNullable) {
     case "int4":
       migration = "$table->integer('" + columnName + "')";
       break;
+    case "int3":
+    case "mediumint":
+	  migration = "$table->mediumInteger('" + columnName + "')";
+	  break;
     case "int2":
+    case "smallint":
       migration = "$table->smallInteger('" + columnName + "')";
       break;
+    case "int1":
     case "tinyint":
       migration = "$table->tinyInteger('" + columnName + "')";
       break;

--- a/tabledump.tableplusplugin/package-lock.json
+++ b/tabledump.tableplusplugin/package-lock.json
@@ -1633,7 +1633,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1651,11 +1652,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1668,15 +1671,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1779,7 +1785,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1789,6 +1796,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1801,17 +1809,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1828,6 +1839,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1900,7 +1912,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1910,6 +1923,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1985,7 +1999,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2015,6 +2030,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2032,6 +2048,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2070,11 +2087,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
- Default values are now supported. (part of #5) Non-integer column default values are run through JSON.stringify to ensure they're properly escaped.
- Support `mediumint`/`int3`.
- Instead of checking for unsigned in each integer case, just check once after the switch and use the `->unsigned()` modifier. (fixes #3 due to removal of unsigned int -> bigIncrements typo)
- Add missing alternate type names `smallint` (in addition to `int2`) and `int1` (in addition to `tinyint`). (fixes #3)