### PR TITLE
Improve the class name of the snake_case type table name

### DIFF
--- a/tabledump.tableplusplugin/library/helper.js
+++ b/tabledump.tableplusplugin/library/helper.js
@@ -12,7 +12,7 @@ function dumpTableAsDefinition(context, item) {
 
 function camelize(str) {
   return str
-    .replace(/(?:^\w|[A-Z]|\b\w)/g, function(letter, index) {
+    .replace(/(?:^\w|[A-Z]|\b\w|_\w)/g, function(letter, index) {
       return letter.toUpperCase();
     })
     .replace(/\s+|-|_/g, "");


### PR DESCRIPTION
Convert snake_case type table names like `foo_bar_baz` to `CreateFooBarBazTable` instead of `CreateFoobarbazTable`.