### PR TITLE
#20 Attempts to resolve MariaDB from being unsupported.

### DIFF
--- a/tabledump.tableplusplugin/library/helper.js
+++ b/tabledump.tableplusplugin/library/helper.js
@@ -142,13 +142,14 @@ class Create${nameCamelcase}Table extends Migration
   var driver = context.driver();
   switch (driver) {
     case "MySQL":
+    case "MariaDB":
       query = `SELECT ordinal_position as ordinal_position,column_name as column_name,column_type AS data_type,is_nullable as is_nullable,column_default as column_default,extra as extra,column_name AS foreign_key,column_comment AS comment FROM information_schema.columns WHERE table_schema='${item.schema()}'AND table_name='${item.name()}';`;
       break;
     case "PostgreSQL":
       query = `SELECT ordinal_position,column_name,udt_name AS data_type,numeric_precision,datetime_precision,numeric_scale,character_maximum_length AS data_length,is_nullable,column_name as check,column_name as check_constraint,column_default,column_name AS foreign_key,pg_catalog.col_description(16402,ordinal_position) as comment FROM information_schema.columns WHERE table_name='${item.name()}'AND table_schema='${item.schema()}';`;
       break;
     default:
-      context.alert("Rrror", driver + " is not supported");
+      context.alert("Error", driver + " is not supported");
       return;
   }
   context.execute(query, res => {


### PR DESCRIPTION
This attempts to resolve the MariaDB driver not supported for Copy As Laravel Migration. MariaDB is a drop-in replacement for MySQL, so this should be supported.

Also this commit fixes a typo in that error message, updates "Rrror to "Error"